### PR TITLE
Bump to Argo 2.6.

### DIFF
--- a/charts/argo-controller/Chart.yaml
+++ b/charts/argo-controller/Chart.yaml
@@ -14,6 +14,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.2.0
 
-appVersion: 2.5
+appVersion: 2.6

--- a/charts/argo-controller/templates/deployment.yaml
+++ b/charts/argo-controller/templates/deployment.yaml
@@ -14,11 +14,11 @@ spec:
       serviceAccount: {{ .Release.Name }}-account
       containers:
         - name: workflow-controller
-          image: argoproj/workflow-controller:v2.5.1
+          image: argoproj/workflow-controller:v2.6.0
           command: [workflow-controller]
           args:
             - --configmap
             - {{ .Release.Name }}-config
             - --executor-image
-            - argoproj/argoexec:v2.5.0
+            - argoproj/argoexec:v2.6.0
             - --namespaced

--- a/charts/argo-server/Chart.yaml
+++ b/charts/argo-server/Chart.yaml
@@ -14,6 +14,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.3.0
 
-appVersion: 2.5
+appVersion: 2.6

--- a/charts/argo-server/templates/deployment.yaml
+++ b/charts/argo-server/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccount: {{ .Release.Name }}-account
       containers:
         - name: argo-server
-          image: argoproj/argocli:v2.5.1
+          image: argoproj/argocli:v2.6.0
           args:
             - server
             - --configmap


### PR DESCRIPTION
No config changes needed; the new version is mainly focused on internal stability / UI tweaks