### PR TITLE
DSPDC-975 Add action to publish changed charts.

### DIFF
--- a/.github/workflows/upload-new-charts.yaml
+++ b/.github/workflows/upload-new-charts.yaml
@@ -1,0 +1,17 @@
+name: Release new charts
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: azure/setup-helm@v1
+        with:
+          version: '3.1.2'
+      - uses: broadinstitute/setup-chart-releaser@v0
+        with:
+          version: '1.0.0-beta.1'
+      - run: ./hack/upload-changed-charts

--- a/.github/workflows/upload-new-charts.yaml
+++ b/.github/workflows/upload-new-charts.yaml
@@ -11,7 +11,9 @@ jobs:
       - uses: azure/setup-helm@v1
         with:
           version: '3.1.2'
-      - uses: broadinstitute/setup-chart-releaser@v0
+      - uses: broadinstitute/setup-chart-releaser@v1
         with:
           version: '1.0.0-beta.1'
       - run: ./hack/upload-changed-charts
+        env:
+          CR_TOKEN: ${{ secrets.ChartReleaserToken }}

--- a/charts/argo-controller/Chart.yaml
+++ b/charts/argo-controller/Chart.yaml
@@ -14,6 +14,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.2
+version: 0.5.3
 
 appVersion: 2.7

--- a/charts/argo-controller/templates/deployment.yaml
+++ b/charts/argo-controller/templates/deployment.yaml
@@ -14,13 +14,13 @@ spec:
       serviceAccount: {{ .Release.Name }}-account
       containers:
         - name: workflow-controller
-          image: argoproj/workflow-controller:v2.7.1
+          image: argoproj/workflow-controller:v2.7.2
           command: [workflow-controller]
           args:
             - --configmap
             - {{ .Release.Name }}-config
             - --executor-image
-            - argoproj/argoexec:v2.7.1
+            - argoproj/argoexec:v2.7.2
             - --namespaced
             {{- if .Values.debug }}
             - --loglevel

--- a/charts/argo-server/Chart.yaml
+++ b/charts/argo-server/Chart.yaml
@@ -14,6 +14,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.6.2
+version: 0.6.3
 
 appVersion: 2.7

--- a/charts/argo-server/templates/deployment.yaml
+++ b/charts/argo-server/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccount: {{ .Release.Name }}-account
       containers:
         - name: argo-server
-          image: argoproj/argocli:v2.7.1
+          image: argoproj/argocli:v2.7.2
           args:
             - server
             - --configmap

--- a/hack/upload-changed-charts
+++ b/hack/upload-changed-charts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+declare -r SCRIPT_DIR=$(cd $(dirname ${0}) >/dev/null 2>&1 && pwd)
+declare -r REPO_ROOT=$(cd $(dirname ${SCRIPT_DIR}) >/dev/null 2>&1 && pwd)
+declare -r TEMP_DIR=${REPO_ROOT}/deploy
+
+function lookup_latest_tag () {
+  git fetch --tags &> /dev/null
+
+  if ! git describe --tags --abbrev=0 2> /dev/null; then
+    git rev-list --max-parents=0 --first-parent HEAD
+  fi
+}
+
+function lookup_changed_charts () {
+  local -r commit=$1
+  local -r changed_files=$(git diff --find-renames --name-only ${commit} -- charts)
+  local -ra changed_prefixes=($(echo ${changed_files} | cut -d / -f 1,2 | uniq))
+
+  for prefix in ${changed_prefixes[@]}; do
+    if [[ -d ${prefix} ]]; then
+      if [[ -f ${prefix}/Chart.yaml ]]; then
+        echo ${prefix}
+      fi
+    fi
+  done
+}
+
+function main () {
+  trap "cd $(pwd)" EXIT
+  cd ${REPO_ROOT}
+
+  1>&2 echo Looking up latest tag...
+  local -r latest_tag=$(lookup_latest_tag)
+
+  1>&2 echo Discovering charts changed since "'${latest_tag}'"...
+  local -ra changed_charts=($(lookup_changed_charts ${latest_tag}))
+
+  if [[ -z "${changed_charts[*]}" ]]; then
+    1>&2 echo No changed charts to upload
+  else
+    1>&2 echo Packaging discovered charts...
+    rm -rf ${TEMP_DIR}
+    mkdir -p ${TEMP_DIR}
+    helm package \
+      --destination ${TEMP_DIR} \
+      --dependency-update \
+      ${changed_charts[@]}
+
+    1>&2 echo Uploading charts...
+    cr upload -o broadinstitute -r monster-helm
+  fi
+}
+
+main


### PR DESCRIPTION
Bash logic is largely copied from [this script](https://github.com/helm/chart-releaser-action/blob/master/cr.sh) in the "official" chart-releaser action. We aren't using that action because it bundles "upload" and "index" together, and we want to split the two to avoid race conditions in indexing.