### PR TITLE
QH - DSPDC-950 - Extend ClinVar Argo workflow to create new temporary BQ tables for ClinGen

### DIFF
--- a/charts/argo-templates/Chart.yaml
+++ b/charts/argo-templates/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: argo-templates
 description: Collection of generic Argo templates
 type: application
-version: 0.0.3-M0
+version: 0.0.2-DSPDC-950

--- a/charts/argo-templates/scripts/diff-bq-table.sh
+++ b/charts/argo-templates/scripts/diff-bq-table.sh
@@ -17,9 +17,9 @@ declare -r FULL_DIFF=$(join_by ' OR ' "${COMPARISONS[@]}")
 
 declare -a PRIMARY_COLUMNS=()
 for col in ${PK_COLS//,/ }; do
-  PRIMARYCOLUMNS+=("${col} as datarepo_${col}")
+  PRIMARY_COLUMNS+=("${col} as datarepo_${col}")
 done
-declare -r SELECT_COLUMNS=$(join_by ', ' "${PRIMARYCOLUMNS[@]}")
+declare -r REPO_KEYS=$(join_by ', ' "${PRIMARY_COLUMNS[@]}")
 
 declare -r TARGET_TABLE=${TABLE}_joined
 
@@ -38,7 +38,7 @@ declare -ra BQ_QUERY=(
   --external_table_definition=${TABLE}::${TABLE_DIR}/schema.json@NEWLINE_DELIMITED_JSON=${GCS_PREFIX}/*
   --destination_table=${STAGING_PROJECT}:${STAGING_DATASET}.${TARGET_TABLE}
 )
-1>&2 ${BQ_QUERY[@]} "SELECT J.datarepo_row_id, S.*, ${SELECTCOLUMNS}
+1>&2 ${BQ_QUERY[@]} "SELECT J.datarepo_row_id, S.*, ${REPO_KEYS}
   FROM ${TABLE} S FULL JOIN \`${JADE_PROJECT}.${JADE_DATASET}.${TABLE}\` J
   USING (${PK_COLS}) WHERE ${FULL_DIFF}"
 

--- a/charts/argo-templates/scripts/diff-bq-table.sh
+++ b/charts/argo-templates/scripts/diff-bq-table.sh
@@ -19,7 +19,7 @@ declare -a PRIMARY_COLUMNS=()
 for col in ${PK_COLS//,/ }; do
   PRIMARYCOLUMNS+=("${col} as datarepo_${col}")
 done
-declare -r SELECTCOLUMNS=$(join_by ', ' "${PRIMARYCOLUMNS[@]}")
+declare -r SELECT_COLUMNS=$(join_by ', ' "${PRIMARYCOLUMNS[@]}")
 
 declare -r TARGET_TABLE=${TABLE}_joined
 

--- a/charts/argo-templates/scripts/diff-bq-table.sh
+++ b/charts/argo-templates/scripts/diff-bq-table.sh
@@ -15,7 +15,7 @@ for c in ${COMPARE_COLS//,/ }; do
 done
 declare -r FULL_DIFF=$(join_by ' OR ' "${COMPARISONS[@]}")
 
-declare -a PRIMARYCOLUMNS=()
+declare -a PRIMARY_COLUMNS=()
 for col in ${PK_COLS//,/ }; do
   PRIMARYCOLUMNS+=("${col} as datarepo_${col}")
 done

--- a/charts/argo-templates/templates/diff-bq-table.yaml
+++ b/charts/argo-templates/templates/diff-bq-table.yaml
@@ -137,7 +137,9 @@ spec:
           - name: rows-to-append-count
             valueFrom:
               parameter: '{{ "{{tasks.query-row-count.outputs.result}}" }}'
-
+          - name: join-table-name-output
+            valueFrom:
+              parameter: '{{ "{{tasks.join-staging-to-existing.outputs.result}}" }}'
     - name: join-staging-to-existing
       inputs:
         parameters:

--- a/charts/argo-templates/templates/diff-bq-table.yaml
+++ b/charts/argo-templates/templates/diff-bq-table.yaml
@@ -137,7 +137,7 @@ spec:
           - name: rows-to-append-count
             valueFrom:
               parameter: '{{ "{{tasks.query-row-count.outputs.result}}" }}'
-          - name: join-table-name-output
+          - name: join-table-name
             valueFrom:
               parameter: '{{ "{{tasks.join-staging-to-existing.outputs.result}}" }}'
     - name: join-staging-to-existing


### PR DESCRIPTION
Modified diff-bq-table.yaml to have one  more output (join table name output).
Modified diff-bq-table.sh to create a new array of the primary cols so that they can be pulled out with a different alias within the SQL query and so they can be slurped by argo at the main level.
Updated the Chart version number within this repo as well as version numbers, referenced branch, and CRON schedule within clinvar-ingest and monster-deploy projects (for testing).