### PR TITLE
DSPDC-1049 Use dedicated input for diff-bq-table version.

### DIFF
--- a/charts/argo-templates/Chart.yaml
+++ b/charts/argo-templates/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: argo-templates
 description: Collection of generic Argo templates
 type: application
-version: 0.0.5
+version: 0.0.6
 

--- a/charts/argo-templates/templates/diff-bq-table.yaml
+++ b/charts/argo-templates/templates/diff-bq-table.yaml
@@ -1,9 +1,10 @@
-{{- if .Values.diffBQTable.create }}
-{{- $schemaImage := printf "%s:%s" .Values.diffBQTable.schemaImageName (default "latest" .Chart.AppVersion) }}
+{{- with .Values.diffBQTable }}
+{{- if .create }}
+{{- $schemaImage := printf "%s:%s" .schemaImageName (default "latest" .schemaImageVersion ) }}
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: {{ .Values.diffBQTable.name }}
+  name: {{ .name }}
 spec:
   templates:
     - name: main
@@ -140,25 +141,27 @@ spec:
           - name: join-table-name
             valueFrom:
               parameter: '{{ "{{tasks.join-staging-to-existing.outputs.result}}" }}'
+      {{- if .generateMetrics }}
       metrics:
         prometheus:
           {{- include "argo.collect-execution-metrics" . | indent 10 }}
           - name: rows_to_delete
             help: 'Number of rows to be deleted'
-            labels: 
+            labels:
               - key: table-name
               - value: '{{inputs.parameters.table-name}}'
             when: '{{status}} == Succeeded'
-            gauge: 
+            gauge:
               value: '{{ outputs.parameters.ids-to-delete-count }}'
           - name: rows_to_append
             help: 'Number of rows to be added'
-            labels: 
+            labels:
               - key: table-name
               - value: '{{inputs.parameters.table-name}}'
             when: '{{status}} == Succeeded'
-            gauge: 
+            gauge:
               value: '{{ outputs.parameters.rows-to-append-count }}'
+      {{- end }}
 
     - name: join-staging-to-existing
       inputs:
@@ -284,4 +287,5 @@ spec:
         command: [bash]
         source: |
         {{- include "argo.render-lines" (.Files.Lines "scripts/extract-bq-table.sh") | indent 10 }}
+{{- end }}
 {{- end }}

--- a/charts/argo-templates/values.schema.json
+++ b/charts/argo-templates/values.schema.json
@@ -63,7 +63,9 @@
       "properties": {
         "create": { "type": "boolean" },
         "name": { "type": "string" },
-        "schemaImageName": { "type": "string" }
+        "schemaImageName": { "type": "string" },
+        "schemaImageVersion": { "type": "string" },
+        "generateMetrics": { "type": "boolean" }
       },
       "required": ["create"]
     }

--- a/charts/argo-templates/values.yaml
+++ b/charts/argo-templates/values.yaml
@@ -14,3 +14,4 @@ createBQDataset:
   create: false
 diffBQTable:
   create: false
+  generateMetrics: false


### PR DESCRIPTION
Using `.Chart.AppVersion` doesn't work now that we've pulled the template into a sub-chart.