### PR TITLE
Bump argo controller resource requests

### DIFF
--- a/charts/argo-controller/templates/config.yaml
+++ b/charts/argo-controller/templates/config.yaml
@@ -65,9 +65,9 @@ data:
   {{- end }}
   executorResources: |
     requests:
-      cpu: 100m
-      memory: 64Mi
-      ephemeral-storage: 4Mi
+      cpu: 200m
+      memory: 256Mi
+      ephemeral-storage: 8Mi
     limits:
       cpu: 500m
       memory: 512Mi


### PR DESCRIPTION
## Why
When running numerous Argo Workflows on the same cluster, the argo controller started crashing with an error code of 137, which is a health check issue that is commonly an "out of memory" issue. I dynamically bumped up the memory and it resolved the issue, so it would be good to bump up the request in the config map used to set the resource requests for the argo controller process.

## This PR
Increase cpu/memory/storage requests for argo controller