### PR TITLE
bump chart version of argo-controller

### DIFF
--- a/.github/workflows/release-new-charts.yaml
+++ b/.github/workflows/release-new-charts.yaml
@@ -18,6 +18,6 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - name: Validate charts
         run: ./hack/validate-charts
-      - uses: helm/chart-releaser-action@v1.0.0-rc.1
+      - uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/argo-controller/Chart.yaml
+++ b/charts/argo-controller/Chart.yaml
@@ -14,6 +14,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.3
+version: 0.7.4
 
 appVersion: 2.7


### PR DESCRIPTION
## Why
The chart release didn't work because I forgot to bump the chart version for the argo-controller

## This PR
Updates the chart version for the argo-controller