### PR TITLE
Ra actually fix argo controller

### DIFF
--- a/charts/argo-controller/Chart.yaml
+++ b/charts/argo-controller/Chart.yaml
@@ -14,6 +14,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.4
+version: 0.7.5
 
 appVersion: 2.7

--- a/charts/argo-controller/templates/config.yaml
+++ b/charts/argo-controller/templates/config.yaml
@@ -65,9 +65,9 @@ data:
   {{- end }}
   executorResources: |
     requests:
-      cpu: 200m
-      memory: 256Mi
-      ephemeral-storage: 8Mi
+      cpu: 100m
+      memory: 128Mi
+      ephemeral-storage: 4Mi
     limits:
       cpu: 500m
       memory: 512Mi

--- a/charts/argo-controller/templates/deployment.yaml
+++ b/charts/argo-controller/templates/deployment.yaml
@@ -38,8 +38,8 @@ spec:
           {{- end }}
           resources:
             requests:
-              cpu: 1000m
-              memory: 128Mi
-            limits:
               cpu: 2000m
               memory: 256Mi
+            limits:
+              cpu: 4000m
+              memory: 512Mi


### PR DESCRIPTION
## Why
I did not bump the right thing on the previous release; I had bumped up the resource requests for executors, not the controller. Need to fix that and bump up the controller.

## This PR
This bumps the executor resource requests back down (not entirely, I did give them a little more memory), and bumps up the actual resource requests/limits for the controller. Updates the chart version as well.