### PR TITLE
Slack notification workflow template

### DIFF
--- a/charts/argo-templates/example-values/notification.yaml
+++ b/charts/argo-templates/example-values/notification.yaml
@@ -1,0 +1,5 @@
+notification:
+  create: true
+  oauthToken:
+    secretName: aaaaa
+    secretKey: bbbbb

--- a/charts/argo-templates/templates/notification.yaml
+++ b/charts/argo-templates/templates/notification.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.notification.create }}
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
@@ -7,8 +8,8 @@ spec:
     - name: send-slack-notification
       inputs:
         parameters:
-          - name: channel-id
-          - name: message-text
+          - name: channel
+          - name: text
       container:
         image: curlimages/curl:7.70.0
         env:
@@ -18,6 +19,8 @@ spec:
                 name: {{ .Values.notification.oauthToken.secretName }}
                 key: {{ .Values.notification.oauthToken.secretKey }}
         command: [ curl ]
+        {{- $text := "{{inputs.parameters.text}}" }}
+        {{- $channel := "{{inputs.parameters.channel}}" }}
         args:
           - -XPOST
           - -H
@@ -25,5 +28,6 @@ spec:
           - -H
           - 'Authorization: Bearer $(OAUTH_TOKEN)'
           - -d
-          - '{"text": "{{inputs.parameters.message-text}}", "channel": "{{inputs.parameters.channel-name}}"}'
+          - '{"text": "{{$text}}", "channel": "{{$channel}}"}'
           - "https://slack.com/api/chat.postMessage"
+{{- end }}

--- a/charts/argo-templates/templates/notification.yaml
+++ b/charts/argo-templates/templates/notification.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: notification-templates
+spec:
+  templates:
+    - name: send-slack-notification
+      inputs:
+        parameters:
+          - name: channel-id
+          - name: message-text
+      container:
+        image: curlimages/curl:7.70.0
+        env:
+          - name: OAUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.notification.oauthToken.secretName }}
+                key: {{ .Values.notification.oauthToken.secretKey }}
+        command: [ curl ]
+        args:
+          - -XPOST
+          - -H
+          - 'Content-type: application/json'
+          - -H
+          - 'Authorization: Bearer $(OAUTH_TOKEN)'
+          - -d
+          - '{"text": "{{inputs.parameters.message-text}}", "channel": "{{inputs.parameters.channel-name}}"}'
+          - "https://slack.com/api/chat.postMessage"

--- a/charts/argo-templates/values.schema.json
+++ b/charts/argo-templates/values.schema.json
@@ -120,9 +120,45 @@
         "name": { "type": "string" }
       },
       "required": ["create"]
+    },
+    "notification": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "create": {
+              "const": false
+            }
+          },
+          "additionalProperties": false,
+          "required": ["create"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "oauthToken": {
+              "type": "object",
+              "properties": {
+                "secretName": {
+                  "type": "string"
+                },
+                "secretKey": {
+                  "type": "string"
+                }
+              },
+              "required": ["secretName", "secretKey"]
+            }
+          },
+          "required": ["create", "oauthToken" ]
+        }
+      ]
     }
   },
   "required": ["generatePVC", "deletePVC", "downloadFTPFile", "downloadS3File",
                "copyToGCS", "gsutilRsync", "createBQDataset", "diffBQTable", "exportBQTable",
-               "ingestFile", "ingestTable", "softDeleteTable", "lookupFileId"]
+               "ingestFile", "ingestTable", "softDeleteTable", "lookupFileId",
+               "notification"]
 }

--- a/charts/argo-templates/values.yaml
+++ b/charts/argo-templates/values.yaml
@@ -24,3 +24,5 @@ softDeleteTable:
   create: false
 lookupFileId:
   create: false
+notification:
+  create: false


### PR DESCRIPTION
## Why
It's tricky to get slack notifications right, including the payload format and proper escaping for the auth token. That functionality should get captured in a reusable template.

## This PR
* Creates a `notifications` template file with a `send-slack-notification` template 
