### PR TITLE
Offload Argo node status to a DB

### DIFF
--- a/.github/workflows/release-new-charts.yaml
+++ b/.github/workflows/release-new-charts.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - arh-shave-yak
 jobs:
   release-charts:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-new-charts.yaml
+++ b/.github/workflows/release-new-charts.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - arh-shave-yak
 jobs:
   release-charts:
     runs-on: ubuntu-latest

--- a/charts/argo-controller/Chart.yaml
+++ b/charts/argo-controller/Chart.yaml
@@ -14,6 +14,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.6
+version: 0.7.7
 
 appVersion: 2.7

--- a/charts/argo-controller/templates/deployment.yaml
+++ b/charts/argo-controller/templates/deployment.yaml
@@ -28,6 +28,8 @@ spec:
             {{- end }}
           {{- if .Values.debug }}
           env:
+            - name: ALWAYS_OFFLOAD_NODE_STATUS
+              value: "true"
             - name: UPPERIO_DB_DEBUG
               value: "1"
           {{- end }}


### PR DESCRIPTION
We were running into hung workflows. This was due to Argo attempting to update workflow state in gigantic YAML files, which th e K8S API was unable to process.

This PR flips on an ENV var that will use a DB instead of K8S for workflow state storage.