### PR TITLE
Always store workflow status in the DB

### DIFF
--- a/.github/workflows/release-new-charts.yaml
+++ b/.github/workflows/release-new-charts.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - arh-shave-yak2
 jobs:
   release-charts:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-new-charts.yaml
+++ b/.github/workflows/release-new-charts.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - arh-shave-yak2
 jobs:
   release-charts:
     runs-on: ubuntu-latest

--- a/charts/argo-controller/Chart.yaml
+++ b/charts/argo-controller/Chart.yaml
@@ -14,6 +14,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.0
+version: 0.8.1
 
 appVersion: 2.7

--- a/charts/argo-controller/Chart.yaml
+++ b/charts/argo-controller/Chart.yaml
@@ -14,6 +14,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.9
+version: 0.8.0
 
 appVersion: 2.7

--- a/charts/argo-controller/Chart.yaml
+++ b/charts/argo-controller/Chart.yaml
@@ -14,6 +14,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.8
+version: 0.7.9
 
 appVersion: 2.7

--- a/charts/argo-controller/Chart.yaml
+++ b/charts/argo-controller/Chart.yaml
@@ -14,6 +14,6 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.7.7
+version: 0.7.8
 
 appVersion: 2.7

--- a/charts/argo-controller/templates/config.yaml
+++ b/charts/argo-controller/templates/config.yaml
@@ -66,7 +66,7 @@ data:
   executorResources: |
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
       ephemeral-storage: 4Mi
     limits:
       cpu: 500m

--- a/charts/argo-controller/templates/deployment.yaml
+++ b/charts/argo-controller/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           resources:
             requests:
               cpu: 2000m
-              memory: 2500Mi
+              memory: 2048Mi
             limits:
               cpu: 4000m
               memory: 4096Mi

--- a/charts/argo-controller/templates/deployment.yaml
+++ b/charts/argo-controller/templates/deployment.yaml
@@ -26,13 +26,11 @@ spec:
             - --loglevel
             - debug
             {{- end }}
-          {{- if .Values.debug }}
           env:
             - name: ALWAYS_OFFLOAD_NODE_STATUS
               value: "true"
             - name: UPPERIO_DB_DEBUG
               value: "1"
-          {{- end }}
           {{- if .Values.metrics.enabled }}
           ports:
             - containerPort: {{ .Values.metrics.port }}

--- a/charts/argo-controller/templates/deployment.yaml
+++ b/charts/argo-controller/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           resources:
             requests:
               cpu: 2000m
-              memory: 2048Mi
+              memory: 2500Mi
             limits:
               cpu: 4000m
               memory: 4096Mi


### PR DESCRIPTION
The previous fix to store workflow state in the DB was gated by a debug gate, this change removes it as we want this change everywhere.