### PR TITLE
Retry diff-bq-table on error

### DIFF
--- a/.github/workflows/release-new-charts.yaml
+++ b/.github/workflows/release-new-charts.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - arh-dspdc-1864-retry-bq-ops
 jobs:
   release-charts:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-new-charts.yaml
+++ b/.github/workflows/release-new-charts.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - arh-dspdc-1864-retry-bq-ops
 jobs:
   release-charts:
     runs-on: ubuntu-latest

--- a/charts/argo-templates/Chart.yaml
+++ b/charts/argo-templates/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: argo-templates
 description: Collection of generic Argo templates
 type: application
-version: 1.2.4
+version: 1.2.5

--- a/charts/argo-templates/Chart.yaml
+++ b/charts/argo-templates/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: argo-templates
 description: Collection of generic Argo templates
 type: application
-version: 1.2.5
+version: 1.2.6

--- a/charts/argo-templates/templates/diff-bq-table.yaml
+++ b/charts/argo-templates/templates/diff-bq-table.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   templates:
     - name: main
+      {{- include "argo.retry" . | indent 6 }}
       inputs:
         parameters:
           - name: table-name


### PR DESCRIPTION
[Relevant ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1864) 

The constituent steps in this workflow often fail due to 502s and other errors from BigQuery. This workflow diffs a staged  table against the contents of a Jade table and emits the results to a bucket. In the event of a failure, we should rerun these steps as the new outputs will overwrite any existing outputs (i.e., we are protected against having duplicate entries). 

This PR uses an existing argo retry mechanism we are already using for GCS steps and adds it to the overall diff-bq-table template DAG.